### PR TITLE
Update bbrf.py

### DIFF
--- a/src/bbrf.py
+++ b/src/bbrf.py
@@ -556,9 +556,9 @@ class BBRFClient:
             
             # If the provided hostname in -d does not match the parsed hostname,
             # we won't add it to avoid polluting the dataset
-            if u.hostname and not u.hostname == hostname:
-                self.debug("Provided hostname "+hostname+" did not match parsed hostname "+u.hostname+", skipping...")
-                continue
+            # if u.hostname and not u.hostname == hostname:
+            #     self.debug("Provided hostname "+hostname+" did not match parsed hostname "+u.hostname+", skipping...")
+            #     continue
                 
             # If the provided URL is relative, we need to rewrite the URL
             # with the provided hostname, and we will ALWAYS assume http port 80
@@ -582,7 +582,7 @@ class BBRFClient:
                 self.debug("skipping outscoped hostname: "+hostname)
                 continue
             # It must match the in scope
-            if not self.get_program() == '@INFER' and not self.matches_scope(hostname, inscope):
+            if not self.get_program() == '@INFER' and not REGEX_IP.match(hostname) and not self.matches_scope(hostname, inscope):
                 self.debug("skipping not inscope hostname: "+hostname)
                 continue
             


### PR DESCRIPTION
添加url时，默认只允许添加域名，如果要添加ip，可以通过-d参数指定域名，但使用-d参数指定域名，会bbrf会判断ip解析的域名和-d指定的域名是否一致，不一致则禁止添加 解决方式：
	1. 判断域名范围处，加入一处判断条件，如果hostname为ip，则不进入判断 删除判断ip解析的域名和-d指定的域名是否一致的代码